### PR TITLE
Updated createSession to enable onLoad to use composed dispatch

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -83,12 +83,13 @@ export function createSession (opts = {}) {
       storage.set(ns, state, _opts);
     }, opts.throttle);
 
-    // dispatch action to hydrate state (if any)
-    if (storage.has(ns, _opts)) {
-      opts.onLoad(storage.get(ns, _opts), dispatch);
-    }
-
     return next => action => {
+      
+      // dispatch action to hydrate state (if any)
+      if (storage.has(ns, _opts)) {
+        opts.onLoad(storage.get(ns, _opts), next);
+      }
+
       // dispatch the action
       next(action);
 


### PR DESCRIPTION
Hey! Thanks for the library. 

Perhaps I am missing something, but if you want to be able to use the composed dispatch (with other middleware) from within onLoad(), you need to pass next rather than dispatch as a param (see commit).

Then, createSession(storedState, dispatch) will actually have the correct dispatch function. 

Cheers,

Andrew