### PR TITLE
Allow passing a custom debounce function through options

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -78,7 +78,7 @@ export function createSession (opts = {}) {
 
   return function ({ getState, dispatch }) {
     // the function that will update storage
-    const updateStorage = debounce(function () {
+    const updateStorage = (opts.debounce || debounce)(function () {
       const state = opts.selectState(getState());
       storage.set(ns, state, _opts);
     }, opts.throttle);


### PR DESCRIPTION
The current implementation of debounce ignores trailing calls, not saving the state during the backoff period. eg, with a 5000ms throttle:

0s modify state (state is saved)
1s modify state (function throttled, state not saved)
... do nothing else

In this case, the changes made at 1s are never saved, even at the end of the backoff period. lodash implementation has the "trailing" option, that fixes this problem by always executing the last call.

An alternate fix would be to copy (or import) lodash.debounce [1], which implements more fine tuning.

1. https://lodash.com/docs/4.17.4#debounce