### PR TITLE
Allow middleware to chains the passed action

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,2 @@
+node_modules/
+npm-debug.log

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "redux-session",
+  "name": "@samuelsantia/redux-session",
   "version": "1.0.1",
   "description": "Automatically cache parts (or all) of your state in localStorage, sessionStorage or cookies.",
   "main": "dist/index.js",
@@ -17,7 +17,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/helpfulhuman/redux-session.git"
+    "url": "git+https://github.com/samuelsantia/redux-session.git"
   },
   "keywords": [
     "redux",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@samuelsantia/redux-session",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Automatically cache parts (or all) of your state in localStorage, sessionStorage or cookies.",
   "main": "dist/index.js",
   "jsnext:main": "src/index.js",

--- a/src/index.js
+++ b/src/index.js
@@ -90,7 +90,7 @@ export function createSession (opts = {}) {
 
     return next => action => {
       // dispatch the action
-      next(action);
+      const result = next(action);
 
       // flag for whether storage should be cleared.
       const shouldClearStorage = opts.clearStorage(action);
@@ -100,6 +100,8 @@ export function createSession (opts = {}) {
 
       // otherwise, update storage with the latest
       else updateStorage();
+
+      return result;
     }
   }
 }

--- a/test/createSession.js
+++ b/test/createSession.js
@@ -200,4 +200,14 @@ describe('createSession()', function () {
     expect(testAdapter.set).to.have.been.calledWith(ns, selectedState);
   });
 
+  it('the created middleware chains the passed action', function () {
+    const action = { type: 'TEST' };
+    const session = createSession({ ns, adapter: testAdapter });
+    testStore.dispatch.withArgs(action).returns(action);
+
+    const result = session(testStore)(testStore.dispatch)(action);
+
+    expect(testStore.dispatch).to.have.been.calledWith(action);
+    expect(result).to.be.equal(action);
+  });
 });


### PR DESCRIPTION
In some cases you need get dispatched action when performs it.

Or if you use it with others middlewares to can pass it where that you need.
For example if you have `applyMiddleware([ session, myOtherMiddleware])` without the returned action myOtherMiddleware will receive undefined as action and it can't handle it.

Soz about my english 😊 